### PR TITLE
Add happy little manifests

### DIFF
--- a/AutoChicken.gd
+++ b/AutoChicken.gd
@@ -1,7 +1,14 @@
 extends Node2D
 
+# all chickens share the same zone_size, since the collision
+# rect is copied among them.  you could create the collision
+# rect on _ready, if you wanted each chicken to have a unique
+# zone size
 export var zone_size: Vector2 = Vector2(128,128)
 export var random_position = true
+
+func manifest():
+	return StorageManifest.position_manifest(self)
 
 func _ready():
 	if random_position:

--- a/AutoChicken.gd
+++ b/AutoChicken.gd
@@ -5,13 +5,24 @@ extends Node2D
 # rect on _ready, if you wanted each chicken to have a unique
 # zone size
 export var zone_size: Vector2 = Vector2(128,128)
-export var random_position = true
 
+var _world_manifest = {}
+func set_manifest(mfst: Dictionary):
+	_world_manifest = mfst
+
+onready var collision_rect: RectangleShape2D = $Area2D/CollisionShape2D.shape
 func manifest():
-	return StorageManifest.position_manifest(self)
+	var mf = StorageManifest.position_manifest(self)
+	mf["size_x"] =collision_rect.extents.x
+	mf["size_y"] = collision_rect.extents.y
+	return mf
 
 func _ready():
-	if random_position:
+	var mfst_entry = StorageManifest.find_entry(self, _world_manifest)
+	
+	if mfst_entry.empty():
 		position = Vector2(randi()%Chunk.width(), randi()%Chunk.height())
-	var collision_rect: RectangleShape2D = $Area2D/CollisionShape2D.shape
-	collision_rect.extents = zone_size
+		collision_rect.extents = zone_size
+	else:
+		position = Vector2(mfst_entry["position_x"], mfst_entry["position_y"])
+		collision_rect.extents = Vector2(mfst_entry["size_x"], mfst_entry["size_y"])

--- a/AutoChunk.gd
+++ b/AutoChunk.gd
@@ -69,7 +69,6 @@ func init(chunk_id: Vector2):
 		add_child(house)
 		house.set_owner(self)# set owner so that resource saving works
 
-	print("chunk _init complete: %s" % chunk_id)
 
 var live = false
 func _ready():
@@ -86,7 +85,6 @@ func _ready():
 	area_2d.add_child(collision_area)
 	collision_area.set_owner(self) # set owner so that resource saving works
 	live = true
-	print("chunk _ready complete: %s" % chunk_id)
 
 func _on_Chunk_entered(body: PhysicsBody2D):
 	if live && body == player:

--- a/AutoChunk.gd
+++ b/AutoChunk.gd
@@ -50,7 +50,6 @@ func init(chunk_id: Vector2):
 
 	for i in range(NUM_CHICKENS):
 		var cluck = AutoChicken.instance()
-		cluck.zone_size = Vector2(32,32)
 		add_child(cluck)
 		cluck.set_owner(self) # set owner so that resource saving works
 

--- a/AutoChunk.gd
+++ b/AutoChunk.gd
@@ -12,7 +12,7 @@ const ProcPonds = preload("res://ProcPonds.tscn")
 var chunk_id = null
 onready var player = $"/root/ProcFarm".find_node("Player",true)
 
-const NUM_CHICKENS = 0
+const NUM_CHICKENS = 4
 const PLANT_SIZES = [
 		Vector2(512,1024),
 		Vector2(1024,512),
@@ -79,22 +79,24 @@ var live = false
 func _ready():
 	connect("player_entered_chunk", get_parent(), "_on_player_entered_chunk")
 	var area_is_declared = false
+	var area_2d = null
 	for child in get_children():
 		if child is Area2D:
+			area_2d = child
 			area_is_declared = true
 			break
 	if !area_is_declared:
-		var area_2d = Area2D.new()
+		area_2d = Area2D.new()
 		area_2d.position.x += Chunk.width() / 2
 		area_2d.position.y += Chunk.height() / 2
 		var collision_area = CollisionShape2D.new()
 		collision_area.shape = RectangleShape2D.new()
 		collision_area.shape.extents = Chunk.size() / 2
-		area_2d.connect("body_entered", self, "_on_Chunk_entered")
 		add_child(area_2d)
 		area_2d.set_owner(self) # set owner so that resource saving works, https://godotengine.org/qa/903/how-to-save-a-scene-at-run-time
 		area_2d.add_child(collision_area)
 		collision_area.set_owner(self) # set owner so that resource saving works
+	area_2d.connect("body_entered", self, "_on_Chunk_entered")
 	live = true
 
 func _on_Chunk_entered(body: PhysicsBody2D):

--- a/AutoChunk.gd
+++ b/AutoChunk.gd
@@ -79,17 +79,23 @@ func init(chunk_id: Vector2, manifest: Dictionary = {}):
 var live = false
 func _ready():
 	connect("player_entered_chunk", get_parent(), "_on_player_entered_chunk")
-	var area_2d = Area2D.new()
-	area_2d.position.x += Chunk.width() / 2
-	area_2d.position.y += Chunk.height() / 2
-	var collision_area = CollisionShape2D.new()
-	collision_area.shape = RectangleShape2D.new()
-	collision_area.shape.extents = Chunk.size() / 2
-	area_2d.connect("body_entered", self, "_on_Chunk_entered")
-	add_child(area_2d)
-	area_2d.set_owner(self) # set owner so that resource saving works, https://godotengine.org/qa/903/how-to-save-a-scene-at-run-time
-	area_2d.add_child(collision_area)
-	collision_area.set_owner(self) # set owner so that resource saving works
+	var area_is_declared = false
+	for child in get_children():
+		if child is Area2D:
+			area_is_declared = true
+			break
+	if !area_is_declared:
+		var area_2d = Area2D.new()
+		area_2d.position.x += Chunk.width() / 2
+		area_2d.position.y += Chunk.height() / 2
+		var collision_area = CollisionShape2D.new()
+		collision_area.shape = RectangleShape2D.new()
+		collision_area.shape.extents = Chunk.size() / 2
+		area_2d.connect("body_entered", self, "_on_Chunk_entered")
+		add_child(area_2d)
+		area_2d.set_owner(self) # set owner so that resource saving works, https://godotengine.org/qa/903/how-to-save-a-scene-at-run-time
+		area_2d.add_child(collision_area)
+		collision_area.set_owner(self) # set owner so that resource saving works
 	live = true
 
 func _on_Chunk_entered(body: PhysicsBody2D):

--- a/AutoChunk.gd
+++ b/AutoChunk.gd
@@ -15,14 +15,14 @@ onready var player = $"/root/ProcFarm".find_node("Player",true)
 const NUM_CHICKENS = 0
 const PLANT_SIZES = [
 		Vector2(512,1024),
-#		Vector2(1024,512),
-#		Vector2(512,768),
-#		Vector2(768,256),
-#		Vector2(384,384)
+		Vector2(1024,512),
+		Vector2(512,768),
+		Vector2(768,256),
+		Vector2(384,384)
 	]
 const NUM_PONDS = 1
 const DRAW_HOUSE = false
-const DRAW_FENCED_COW = false
+const DRAW_FENCED_COW = true
 
 var _storage_name = null
 func storage_name():

--- a/AutoChunk.gd
+++ b/AutoChunk.gd
@@ -43,7 +43,6 @@ func init(chunk_id: Vector2, manifest: Dictionary = {}):
 	)
 
 	var field = ProcField.instance()
-#	set_manifest(field, manifest)
 	add_child(field)
 	field.set_owner(self) # set owner so that resource saving works, https://godotengine.org/qa/903/how-to-save-a-scene-at-run-time
 

--- a/AutoChunk.gd
+++ b/AutoChunk.gd
@@ -31,12 +31,6 @@ func storage_name():
 	return _storage_name
 
 const SET_MANIFEST_METHOD = "set_manifest"
-#func use_manifest(node: Node, manifest: Dictionary) -> bool:
-#	return manifest && !manifest.empty() && node && node.has_method(SET_MANIFEST_METHOD)
-#func set_manifest(node: Node, manifest: Dictionary):
-#	if use_manifest(node, manifest):
-#		print("use use use")
-#		node.call(SET_MANIFEST_METHOD, manifest)
 
 # The presence of a manifest indicates that procedurally
 # generated areas should have positions, sizes, etc
@@ -57,13 +51,11 @@ func init(chunk_id: Vector2, manifest: Dictionary = {}):
 	# Because ProcFencedCow does not respect other nodes' proc zones
 	if DRAW_FENCED_COW:
 		var fenced_cow = ProcFencedCow.instance()
-#		set_manifest(fenced_cow, manifest)
 		add_child(fenced_cow)
 		fenced_cow.set_owner(self) # set owner so that resource saving works
 
 	for i in range(NUM_CHICKENS):
 		var cluck = AutoChicken.instance()
-#		set_manifest(cluck, manifest)
 		add_child(cluck)
 		cluck.set_owner(self) # set owner so that resource saving works
 

--- a/AutoChunk.gd
+++ b/AutoChunk.gd
@@ -69,7 +69,7 @@ func init(chunk_id: Vector2, manifest: Dictionary = {}):
 
 	for s in PLANT_SIZES:
 		var plants = ProcPlants.instance()
-		plants.size = s
+		plants.max_size = s
 		add_child(plants)
 		plants.set_owner(self) # set owner so that resource saving works
 

--- a/AutoChunk.gd
+++ b/AutoChunk.gd
@@ -12,7 +12,7 @@ const ProcPonds = preload("res://ProcPonds.tscn")
 var chunk_id = null
 onready var player = $"/root/ProcFarm".find_node("Player",true)
 
-const NUM_CHICKENS = 4
+const NUM_CHICKENS = 0
 const PLANT_SIZES = [
 		Vector2(512,1024),
 		Vector2(1024,512),

--- a/AutoChunk.gd
+++ b/AutoChunk.gd
@@ -12,17 +12,17 @@ const ProcPonds = preload("res://ProcPonds.tscn")
 var chunk_id = null
 onready var player = $"/root/ProcFarm".find_node("Player",true)
 
-const NUM_CHICKENS = 4
+const NUM_CHICKENS = 0
 const PLANT_SIZES = [
 		Vector2(512,1024),
-		Vector2(1024,512),
-		Vector2(512,768),
-		Vector2(768,256),
-		Vector2(384,384)
+#		Vector2(1024,512),
+#		Vector2(512,768),
+#		Vector2(768,256),
+#		Vector2(384,384)
 	]
-const NUM_PONDS = 2
-const DRAW_HOUSE = true
-const DRAW_FENCED_COW = true
+const NUM_PONDS = 1
+const DRAW_HOUSE = false
+const DRAW_FENCED_COW = false
 
 var _storage_name = null
 func storage_name():
@@ -30,7 +30,18 @@ func storage_name():
 		_storage_name = "chunk_%d_%s" % [OS.get_unix_time(), chunk_id]
 	return _storage_name
 
-func init(chunk_id: Vector2):
+const SET_MANIFEST_METHOD = "set_manifest"
+#func use_manifest(node: Node, manifest: Dictionary) -> bool:
+#	return manifest && !manifest.empty() && node && node.has_method(SET_MANIFEST_METHOD)
+#func set_manifest(node: Node, manifest: Dictionary):
+#	if use_manifest(node, manifest):
+#		print("use use use")
+#		node.call(SET_MANIFEST_METHOD, manifest)
+
+# The presence of a manifest indicates that procedurally
+# generated areas should have positions, sizes, etc
+# restored to the listed values.
+func init(chunk_id: Vector2, manifest: Dictionary = {}):
 	self.chunk_id = chunk_id
 	self.position = Vector2(
 		chunk_id.x * Chunk.width(),
@@ -38,6 +49,7 @@ func init(chunk_id: Vector2):
 	)
 
 	var field = ProcField.instance()
+#	set_manifest(field, manifest)
 	add_child(field)
 	field.set_owner(self) # set owner so that resource saving works, https://godotengine.org/qa/903/how-to-save-a-scene-at-run-time
 
@@ -45,11 +57,13 @@ func init(chunk_id: Vector2):
 	# Because ProcFencedCow does not respect other nodes' proc zones
 	if DRAW_FENCED_COW:
 		var fenced_cow = ProcFencedCow.instance()
+#		set_manifest(fenced_cow, manifest)
 		add_child(fenced_cow)
 		fenced_cow.set_owner(self) # set owner so that resource saving works
 
 	for i in range(NUM_CHICKENS):
 		var cluck = AutoChicken.instance()
+#		set_manifest(cluck, manifest)
 		add_child(cluck)
 		cluck.set_owner(self) # set owner so that resource saving works
 

--- a/AutoChunk.gd
+++ b/AutoChunk.gd
@@ -12,7 +12,7 @@ const ProcPonds = preload("res://ProcPonds.tscn")
 var chunk_id = null
 onready var player = $"/root/ProcFarm".find_node("Player",true)
 
-const NUM_CHICKENS = 0
+const NUM_CHICKENS = 4
 const PLANT_SIZES = [
 		Vector2(512,1024),
 		Vector2(1024,512),
@@ -20,8 +20,8 @@ const PLANT_SIZES = [
 		Vector2(768,256),
 		Vector2(384,384)
 	]
-const NUM_PONDS = 1
-const DRAW_HOUSE = false
+const NUM_PONDS = 2
+const DRAW_HOUSE = true
 const DRAW_FENCED_COW = true
 
 var _storage_name = null

--- a/AutoPlant.gd
+++ b/AutoPlant.gd
@@ -31,6 +31,9 @@ var _manifest = {}
 func manifest():
 	return _manifest
 
+func set_manifest(mfst: Dictionary):
+	print("auto plant set manifest")
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	var zone = ProcZoneRepo.assign_zone(size, chunk_id)

--- a/AutoPlant.gd
+++ b/AutoPlant.gd
@@ -14,6 +14,7 @@ onready var tile_size = Vector2(sprite_size.x + TILE_BUFFER.x, sprite_size.y + T
 
 var size = Vector2(128,128)
 onready var chunk_id = Chunk.id(self)
+onready var stage_num = randi()%stages.size()
 
 # You need to supply the expected array of preloads,
 # or we'll fail gloriously at runtime.  See below.
@@ -43,7 +44,9 @@ func place(zone: Rect2, stage_num: int):
 			plant.position.x = zone.position.x + x * tile_size.x
 			plant.position.y = zone.position.y + y * tile_size.y
 			get_parent().add_child(plant)
-	self.set_manifest(StorageManifest.size_position_manifest(zone))
+	var mf = StorageManifest.size_position_manifest(zone)
+	mf["stage_num"] = stage_num
+	self.set_manifest(mf)
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
@@ -57,11 +60,10 @@ func _ready():
 		var pos = Vector2(mf_entry["position_x"], mf_entry["position_y"])
 		var zone = Rect2(pos, size)
 		ProcZoneRepo.force_assign_zone(zone, chunk_id)
-		var stage_num: int = mf_entry["stage_num"]
+		self.stage_num = mf_entry["stage_num"]
 		place(zone, stage_num)
 	else:
 		var zone = ProcZoneRepo.assign_zone(size, chunk_id)
-		var stage_num = randi()%stages.size()
 		place(zone, stage_num)
 		_manifest = {}
 		_manifest["position_x"] = zone.position.x

--- a/AutoPlant.gd
+++ b/AutoPlant.gd
@@ -26,6 +26,10 @@ func _init(s: Vector2, preloads):
 	mature = preloads[3]
 	harvested = preloads[4]
 
+var _manifest = {}
+func manifest():
+	return _manifest
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	var zone = ProcZoneRepo.assign_zone(size, chunk_id)
@@ -39,4 +43,8 @@ func _ready():
 			plant.position.x = zone.position.x + x * tile_size.x
 			plant.position.y = zone.position.y + y * tile_size.y
 			get_parent().add_child(plant)
+	
+	_manifest.clear()
+	_manifest["zone"] = zone
+	_manifest["stage"] = stage
 	

--- a/AutoPlant.gd
+++ b/AutoPlant.gd
@@ -32,13 +32,10 @@ func manifest():
 func set_manifest(mfst: Dictionary):
 	self._manifest = mfst
 
-# Called when the node enters the scene tree for the first time.
-func _ready():
-	var zone = ProcZoneRepo.assign_zone(size, chunk_id)
+func place(zone: Rect2, stage_num: int):
 	var num_plants_x = max(0,floor(zone.size.x / tile_size.x) - 1)
 	var num_plants_y = max(0,floor(zone.size.y / tile_size.y) - 1)
 	
-	var stage_num = randi()%stages.size()
 	var stage = stages[stage_num]
 	for x in num_plants_x:
 		for y in num_plants_y:
@@ -46,7 +43,13 @@ func _ready():
 			plant.position.x = zone.position.x + x * tile_size.x
 			plant.position.y = zone.position.y + y * tile_size.y
 			get_parent().add_child(plant)
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	var zone = ProcZoneRepo.assign_zone(size, chunk_id)
+	var stage_num = randi()%stages.size()
 	
+	place(zone, stage_num)
 	_manifest.clear()
 	_manifest["zone"] = zone
 	_manifest["stage_num"] = stage_num

--- a/AutoPlant.gd
+++ b/AutoPlant.gd
@@ -14,25 +14,23 @@ onready var tile_size = Vector2(sprite_size.x + TILE_BUFFER.x, sprite_size.y + T
 
 var size = Vector2(128,128)
 onready var chunk_id = Chunk.id(self)
-var plant_name = ""
 
 # You need to supply the expected array of preloads,
 # or we'll fail gloriously at runtime.  See below.
-func _init(s: Vector2, preloads, plant_name: String):
+func _init(s: Vector2, preloads):
 	size = s
 	young = preloads[0]
 	growing = preloads[1]
 	growing2 = preloads[2]
 	mature = preloads[3]
 	harvested = preloads[4]
-	self.plant_name = plant_name
 
 var _manifest = {}
 func manifest():
 	return _manifest
 
 func set_manifest(mfst: Dictionary):
-	print("auto plant set manifest")
+	self._manifest = mfst
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
@@ -52,5 +50,4 @@ func _ready():
 	_manifest.clear()
 	_manifest["zone"] = zone
 	_manifest["stage_num"] = stage_num
-	_manifest["plant_name"] = self.plant_name
 	

--- a/AutoPlant.gd
+++ b/AutoPlant.gd
@@ -51,11 +51,8 @@ func place(zone: Rect2, stage_num: int):
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	var manifest_exists = _manifest && !_manifest.empty()
-	print("AutoPlant trimmed node path: %s" % StorageManifest.trim_path(get_path()))
-	print("Manifest: %s" % _manifest)
 	var mf_entry = StorageManifest.find_entry(self, _manifest)
 	if !mf_entry.empty():	
-		print("autoplant has a manifest entry :) %s" % mf_entry)
 		var size = Vector2(mf_entry["size_x"], mf_entry["size_y"])
 		var pos = Vector2(mf_entry["position_x"], mf_entry["position_y"])
 		var zone = Rect2(pos, size)

--- a/AutoPlant.gd
+++ b/AutoPlant.gd
@@ -13,18 +13,19 @@ const TILE_BUFFER = Vector2(8,8)
 onready var tile_size = Vector2(sprite_size.x + TILE_BUFFER.x, sprite_size.y + TILE_BUFFER.y)
 
 var size = Vector2(128,128)
-
 onready var chunk_id = Chunk.id(self)
+var plant_name = ""
 
 # You need to supply the expected array of preloads,
 # or we'll fail gloriously at runtime.  See below.
-func _init(s: Vector2, preloads):
+func _init(s: Vector2, preloads, plant_name: String):
 	size = s
 	young = preloads[0]
 	growing = preloads[1]
 	growing2 = preloads[2]
 	mature = preloads[3]
 	harvested = preloads[4]
+	self.plant_name = plant_name
 
 var _manifest = {}
 func manifest():
@@ -36,7 +37,8 @@ func _ready():
 	var num_plants_x = max(0,floor(zone.size.x / tile_size.x) - 1)
 	var num_plants_y = max(0,floor(zone.size.y / tile_size.y) - 1)
 	
-	var stage = stages[randi()%stages.size()]
+	var stage_num = randi()%stages.size()
+	var stage = stages[stage_num]
 	for x in num_plants_x:
 		for y in num_plants_y:
 			var plant = stage.instance()
@@ -46,5 +48,6 @@ func _ready():
 	
 	_manifest.clear()
 	_manifest["zone"] = zone
-	_manifest["stage"] = stage
+	_manifest["stage_num"] = stage_num
+	_manifest["plant_name"] = self.plant_name
 	

--- a/AutoPlant.gd
+++ b/AutoPlant.gd
@@ -46,11 +46,22 @@ func place(zone: Rect2, stage_num: int):
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	var zone = ProcZoneRepo.assign_zone(size, chunk_id)
-	var stage_num = randi()%stages.size()
-	
-	place(zone, stage_num)
-	_manifest.clear()
-	_manifest["zone"] = zone
-	_manifest["stage_num"] = stage_num
+	if _manifest == null || _manifest.empty():
+			var zone = ProcZoneRepo.assign_zone(size, chunk_id)
+			var stage_num = randi()%stages.size()
+			place(zone, stage_num)
+			_manifest = {}
+			_manifest["position_x"] = zone.position.x
+			_manifest["position_y"] = zone.position.y
+			_manifest["size_x"] = zone.size.x
+			_manifest["size_y"] = zone.size.y
+			_manifest["stage_num"] = stage_num
+	else:
+			var mf_entry = StorageManifest.find_entry(self, _manifest)
+			var size = Vector2(mf_entry["size_x"], mf_entry["size_y"])
+			var pos = Vector2(mf_entry["position_x"], mf_entry["position_y"])
+			var zone = Rect2(pos, size)
+			ProcZoneRepo.force_assign_zone(zone, chunk_id)
+			var stage_num: int = mf_entry["stage_num"]
+			place(zone, stage_num)
 	

--- a/AutoPlant.gd
+++ b/AutoPlant.gd
@@ -43,25 +43,30 @@ func place(zone: Rect2, stage_num: int):
 			plant.position.x = zone.position.x + x * tile_size.x
 			plant.position.y = zone.position.y + y * tile_size.y
 			get_parent().add_child(plant)
+	self.set_manifest(StorageManifest.size_position_manifest(zone))
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	if _manifest == null || _manifest.empty():
-			var zone = ProcZoneRepo.assign_zone(size, chunk_id)
-			var stage_num = randi()%stages.size()
-			place(zone, stage_num)
-			_manifest = {}
-			_manifest["position_x"] = zone.position.x
-			_manifest["position_y"] = zone.position.y
-			_manifest["size_x"] = zone.size.x
-			_manifest["size_y"] = zone.size.y
-			_manifest["stage_num"] = stage_num
+	var manifest_exists = _manifest && !_manifest.empty()
+	print("AutoPlant trimmed node path: %s" % StorageManifest.trim_path(get_path()))
+	print("Manifest: %s" % _manifest)
+	var mf_entry = StorageManifest.find_entry(self, _manifest)
+	if !mf_entry.empty():	
+		print("autoplant has a manifest entry :) %s" % mf_entry)
+		var size = Vector2(mf_entry["size_x"], mf_entry["size_y"])
+		var pos = Vector2(mf_entry["position_x"], mf_entry["position_y"])
+		var zone = Rect2(pos, size)
+		ProcZoneRepo.force_assign_zone(zone, chunk_id)
+		var stage_num: int = mf_entry["stage_num"]
+		place(zone, stage_num)
 	else:
-			var mf_entry = StorageManifest.find_entry(self, _manifest)
-			var size = Vector2(mf_entry["size_x"], mf_entry["size_y"])
-			var pos = Vector2(mf_entry["position_x"], mf_entry["position_y"])
-			var zone = Rect2(pos, size)
-			ProcZoneRepo.force_assign_zone(zone, chunk_id)
-			var stage_num: int = mf_entry["stage_num"]
-			place(zone, stage_num)
-	
+		var zone = ProcZoneRepo.assign_zone(size, chunk_id)
+		var stage_num = randi()%stages.size()
+		place(zone, stage_num)
+		_manifest = {}
+		_manifest["position_x"] = zone.position.x
+		_manifest["position_y"] = zone.position.y
+		_manifest["size_x"] = zone.size.x
+		_manifest["size_y"] = zone.size.y
+		_manifest["stage_num"] = stage_num
+

--- a/AutoPond.gd
+++ b/AutoPond.gd
@@ -81,7 +81,7 @@ func zone_from_manifest(mfst: Dictionary) -> Rect2:
 	var entry = StorageManifest.find_entry(StorageManifest.trim_path(get_path()), mfst)
 	
 	return Rect2(Vector2(entry["position_x"], entry["position_y"]),
-					Vector2(entry["size_x"],entry["size_y"]))
+					Vector2(entry["size_x"], entry["size_y"]))
 
 func _ready():
 	chunk_id = Chunk.id(self)

--- a/AutoPond.gd
+++ b/AutoPond.gd
@@ -30,12 +30,14 @@ func snap_size():
 	size = Vector2(floor(size.x / Chunk.TILE_SIZE) * Chunk.TILE_SIZE,
 					floor(size.y / Chunk.TILE_SIZE) * Chunk.TILE_SIZE)
 
-func place():
-	chunk_id = Chunk.id(self)
-	set_cell_size()
-	snap_size()
-	
-	var zone: Rect2 = ProcZoneRepo.assign_zone(size, chunk_id)
+func manifest():
+	return StorageManifest.size_position_manifest(self)
+
+var _manifest = {}
+func set_manifest(mfst: Dictionary):
+	self._manifest = mfst
+
+func place(zone: Rect2):
 	position = zone.position
 	
 	var tx = zone.size.x - int(ceil(zone.size.x)) % Chunk.TILE_SIZE
@@ -75,11 +77,19 @@ func place():
 		for y in range(max(0, num_tiles_y - 1)):
 			$TileMap.set_cellv(Vector2(x + 1,y + 1), rand_water_tile())
 
-func manifest():
-	return StorageManifest.size_position_manifest(self)
-
-func set_manifest(mfst: Dictionary):
-	print("pond set manifest")
+func zone_from_manifest(mfst: Dictionary) -> Rect2:
+	#TODO
+	return Rect2(Vector2(0,0),Vector2(0,0))
 
 func _ready():
-	place()
+	chunk_id = Chunk.id(self)
+	set_cell_size()
+	snap_size()
+
+	if _manifest == null || _manifest.empty():
+		var zone: Rect2 = ProcZoneRepo.assign_zone(size, chunk_id)
+		place(zone)
+	else:
+		var zone: Rect2 = zone_from_manifest(_manifest)
+		ProcZoneRepo.force_assign_zone(zone, chunk_id)
+		place(zone)

--- a/AutoPond.gd
+++ b/AutoPond.gd
@@ -79,8 +79,9 @@ func place(zone: Rect2):
 
 func zone_from_manifest(mfst: Dictionary) -> Rect2:
 	var entry = StorageManifest.find_entry(StorageManifest.trim_path(get_path()), mfst)
-	#TODO
-	return Rect2(Vector2(0,0),Vector2(0,0))
+	
+	return Rect2(Vector2(entry["position_x"], entry["position_y"]),
+					Vector2(entry["size_x"],entry["size_y"]))
 
 func _ready():
 	chunk_id = Chunk.id(self)

--- a/AutoPond.gd
+++ b/AutoPond.gd
@@ -78,6 +78,7 @@ func place(zone: Rect2):
 			$TileMap.set_cellv(Vector2(x + 1,y + 1), rand_water_tile())
 
 func zone_from_manifest(mfst: Dictionary) -> Rect2:
+	var entry = StorageManifest.find_entry(StorageManifest.trim_path(get_path()), mfst)
 	#TODO
 	return Rect2(Vector2(0,0),Vector2(0,0))
 

--- a/AutoPond.gd
+++ b/AutoPond.gd
@@ -78,23 +78,16 @@ func place(zone: Rect2):
 		for y in range(max(0, num_tiles_y - 1)):
 			$TileMap.set_cellv(Vector2(x + 1,y + 1), rand_water_tile())
 
-func zone_from_manifest(mfst: Dictionary) -> Rect2:
-	var entry = StorageManifest.find_entry(self, mfst)
-	return Rect2(Vector2(entry["position_x"], entry["position_y"]),
-					Vector2(entry["size_x"], entry["size_y"]))
-
 func _ready():
 	chunk_id = Chunk.id(self)
 	set_cell_size()
 	snap_size()
 
-	var zone = Rect2(0,0,0,0)
-	var mf_entry = StorageManifest.find_entry(self, _manifest)
-	if mf_entry == null || mf_entry.empty():
+	var zone = StorageManifest.find_zone(self, _manifest)
+	if zone == StorageManifest.NO_ZONE:
 		zone = ProcZoneRepo.assign_zone(size, chunk_id)
 		place(zone)
 	else:
-		zone = zone_from_manifest(_manifest)
 		ProcZoneRepo.force_assign_zone(zone, chunk_id)
 		place(zone)
 	self.set_manifest(StorageManifest.size_position_manifest(zone))

--- a/AutoPond.gd
+++ b/AutoPond.gd
@@ -80,9 +80,6 @@ func place(zone: Rect2):
 
 func zone_from_manifest(mfst: Dictionary) -> Rect2:
 	var entry = StorageManifest.find_entry(self, mfst)
-	print("my entry %s" % entry)
-	print("my path %s" % StorageManifest.trim_path(get_path()))
-	print("-")
 	return Rect2(Vector2(entry["position_x"], entry["position_y"]),
 					Vector2(entry["size_x"], entry["size_y"]))
 

--- a/AutoPond.gd
+++ b/AutoPond.gd
@@ -11,8 +11,6 @@ const E_BORDER_TILE = "grass_water_edge_e"
 const S_BORDER_TILE = "grass_water_edge_s"
 const W_BORDER_TILE = "grass_water_edge_w"
 
-const StorageManifest = preload("res://StorageManifest.gd")
-
 var chunk_id = null
 
 func rand_water_tile():

--- a/AutoPond.gd
+++ b/AutoPond.gd
@@ -78,5 +78,8 @@ func place():
 func manifest():
 	return StorageManifest.size_position_manifest(self)
 
+func set_manifest(mfst: Dictionary):
+	print("pond set manifest")
+
 func _ready():
 	place()

--- a/AutoPond.gd
+++ b/AutoPond.gd
@@ -78,8 +78,8 @@ func place(zone: Rect2):
 			$TileMap.set_cellv(Vector2(x + 1,y + 1), rand_water_tile())
 
 func zone_from_manifest(mfst: Dictionary) -> Rect2:
-	var entry = StorageManifest.find_entry(StorageManifest.trim_path(get_path()), mfst)
-	
+	var entry = StorageManifest.find_entry(self, mfst)
+	print("pond storage manifest %s" % entry)
 	return Rect2(Vector2(entry["position_x"], entry["position_y"]),
 					Vector2(entry["size_x"], entry["size_y"]))
 

--- a/AutoPond.gd
+++ b/AutoPond.gd
@@ -11,6 +11,8 @@ const E_BORDER_TILE = "grass_water_edge_e"
 const S_BORDER_TILE = "grass_water_edge_s"
 const W_BORDER_TILE = "grass_water_edge_w"
 
+const StorageManifest = preload("res://StorageManifest.gd")
+
 var chunk_id = null
 
 func rand_water_tile():
@@ -74,6 +76,9 @@ func place():
 	for x in range(max(0, num_tiles_x - 1)):
 		for y in range(max(0, num_tiles_y - 1)):
 			$TileMap.set_cellv(Vector2(x + 1,y + 1), rand_water_tile())
+
+func manifest():
+	return StorageManifest.size_position_manifest(self)
 
 func _ready():
 	place()

--- a/AutoPond.gd
+++ b/AutoPond.gd
@@ -93,5 +93,7 @@ func _ready():
 		place(zone)
 	else:
 		var zone: Rect2 = zone_from_manifest(_manifest)
+		self.size = zone.size
+		print("auto pond zone from manifest %s" % zone)
 		ProcZoneRepo.force_assign_zone(zone, chunk_id)
 		place(zone)

--- a/AutoPond.gd
+++ b/AutoPond.gd
@@ -79,7 +79,6 @@ func place(zone: Rect2):
 
 func zone_from_manifest(mfst: Dictionary) -> Rect2:
 	var entry = StorageManifest.find_entry(self, mfst)
-	print("pond storage manifest %s" % entry)
 	return Rect2(Vector2(entry["position_x"], entry["position_y"]),
 					Vector2(entry["size_x"], entry["size_y"]))
 
@@ -94,6 +93,5 @@ func _ready():
 	else:
 		var zone: Rect2 = zone_from_manifest(_manifest)
 		self.size = zone.size
-		print("auto pond zone from manifest %s" % zone)
 		ProcZoneRepo.force_assign_zone(zone, chunk_id)
 		place(zone)

--- a/HouseThatchedRoof.gd
+++ b/HouseThatchedRoof.gd
@@ -1,7 +1,5 @@
 extends Node2D
 
-const StorageManifest = preload("res://StorageManifest.gd")
-
 var size = Vector2(196,196)
 
 onready var chunk_id = Chunk.id(self)

--- a/HouseThatchedRoof.gd
+++ b/HouseThatchedRoof.gd
@@ -1,8 +1,13 @@
 extends Node2D
 
+const StorageManifest = preload("res://StorageManifest.gd")
+
 var size = Vector2(196,196)
 
 onready var chunk_id = Chunk.id(self)
+
+func manifest():
+	return StorageManifest.position_manifest(self)
 
 func _ready():
 	var zone = ProcZoneRepo.assign_zone(size, chunk_id)

--- a/HouseThatchedRoof.gd
+++ b/HouseThatchedRoof.gd
@@ -4,9 +4,17 @@ var size = Vector2(196,196)
 
 onready var chunk_id = Chunk.id(self)
 
+var _incoming_manifest = {}
+func set_manifest(mf: Dictionary):
+	_incoming_manifest = mf
+
 func manifest():
 	return StorageManifest.position_manifest(self)
 
 func _ready():
-	var zone = ProcZoneRepo.assign_zone(size, chunk_id)
+	var zone = StorageManifest.find_zone(self, _incoming_manifest)
+	if zone == StorageManifest.NO_ZONE:
+		zone = ProcZoneRepo.assign_zone(size, chunk_id)
+	else:
+		ProcZoneRepo.force_assign_zone(zone, chunk_id)
 	self.position = zone.position

--- a/Player.gd
+++ b/Player.gd
@@ -2,7 +2,7 @@ extends KinematicBody2D
 
 const ItemClass = preload("res://Item.gd")
 
-const WALK_SPEED = 666
+const WALK_SPEED = 1500 # 225
 
 var dir = Vector2()
 

--- a/Player.gd
+++ b/Player.gd
@@ -2,7 +2,7 @@ extends KinematicBody2D
 
 const ItemClass = preload("res://Item.gd")
 
-const WALK_SPEED = 2000 # 225
+const WALK_SPEED = 666
 
 var dir = Vector2()
 

--- a/Player.gd
+++ b/Player.gd
@@ -2,7 +2,7 @@ extends KinematicBody2D
 
 const ItemClass = preload("res://Item.gd")
 
-const WALK_SPEED = 225
+const WALK_SPEED = 1000 # 225
 
 var dir = Vector2()
 

--- a/Player.gd
+++ b/Player.gd
@@ -2,7 +2,7 @@ extends KinematicBody2D
 
 const ItemClass = preload("res://Item.gd")
 
-const WALK_SPEED = 1000 # 225
+const WALK_SPEED = 2000 # 225
 
 var dir = Vector2()
 

--- a/ProcChunks.gd
+++ b/ProcChunks.gd
@@ -88,7 +88,7 @@ func restore_chunk(file: String, chunk_id: Vector2):
 	var chunk = storage.load_scene(file)
 	chunk.chunk_id = chunk_id
 	chunk._storage_name = file
-	
+
 	if chunk_manifests.has(chunk_id):
 		print("set manifest %s" % chunk_manifests[chunk_id])
 		deep_set_manifests(chunk, chunk_manifests[chunk_id])

--- a/ProcChunks.gd
+++ b/ProcChunks.gd
@@ -76,7 +76,12 @@ func save_chunk(cr, chunk_id: Vector2):
 	ProcZoneRepo.erase_chunk(chunk_id)
 	print("saved to disk: %s" % cr["storage_name"])
 
+# It's important to pass this flag so that we can easily
+# match the paths generated in the storage manifest.
+# If we don't pass it, `storage.load_scene` will continue
+# to add '@' characters onto the front of the instance name.
 const RESTORE_WITH_LEGIBLE_NAMES = true
+
 # dict prevents multiple calls at the same time
 var _pend_restore = {}
 func restore_chunk(file: String, chunk_id: Vector2):

--- a/ProcChunks.gd
+++ b/ProcChunks.gd
@@ -4,7 +4,6 @@ export var size = Vector2(3,3)
 
 const AutoChunk = preload("res://AutoChunk.tscn")
 const SceneStorage = preload("res://SceneStorage.gd")
-const StorageManifest = preload("res://StorageManifest.gd")
 const DeepZIndexHack = preload("res://DeepZIndexHack.gd")
 
 var active_chunks = {}
@@ -12,7 +11,6 @@ var stored_chunks = {}
 var chunk_manifests = {}
 
 onready var storage = SceneStorage.new()
-onready var manifest = StorageManifest.new()
 onready var dzi: DeepZIndexHack = $"/root/ProcFarm".find_node("DeepZIndexHack",true)
 
 func _ready():
@@ -67,7 +65,7 @@ func _on_player_entered_chunk(chunk_id: Vector2):
 var _pend_save = {}
 func save_chunk(cr, chunk_id: Vector2):
 	var chunk = cr.chunk
-	var cmf = manifest.generate(chunk)
+	var cmf = StorageManifest.generate(chunk)
 	storage.save_scene(chunk, cr["storage_name"])
 	remove_child(chunk)
 	active_chunks.erase(chunk_id)

--- a/ProcChunks.gd
+++ b/ProcChunks.gd
@@ -76,6 +76,7 @@ func save_chunk(cr, chunk_id: Vector2):
 	ProcZoneRepo.erase_chunk(chunk_id)
 	print("saved to disk: %s" % cr["storage_name"])
 
+const RESTORE_WITH_LEGIBLE_NAMES = true
 # dict prevents multiple calls at the same time
 var _pend_restore = {}
 func restore_chunk(file: String, chunk_id: Vector2):
@@ -85,7 +86,7 @@ func restore_chunk(file: String, chunk_id: Vector2):
 	
 	## TODO: descend through the chunk's scene tree and
 	##       call with_manifest() on each individual node
-	add_child(chunk)
+	add_child(chunk, RESTORE_WITH_LEGIBLE_NAMES)
 	chunk.set_owner(get_parent()) # set owner so that resource saving works
 	dzi.call("deep_zindex_hack", chunk)
 	stored_chunks.erase(file)

--- a/ProcChunks.gd
+++ b/ProcChunks.gd
@@ -90,7 +90,6 @@ func restore_chunk(file: String, chunk_id: Vector2):
 	chunk._storage_name = file
 
 	if chunk_manifests.has(chunk_id):
-		print("set manifest %s" % chunk_manifests[chunk_id])
 		deep_set_manifests(chunk, chunk_manifests[chunk_id])
 
 	add_child(chunk, _RESTORE_WITH_LEGIBLE_NAMES)
@@ -102,7 +101,6 @@ func restore_chunk(file: String, chunk_id: Vector2):
 
 const SET_MANIFEST_METHOD = "set_manifest"
 func deep_set_manifests(node, mnfst: Dictionary):
-	print("%s (%s) chlrns %s" % [node,node.name,str(node.get_children())])
 	if node.has_method(SET_MANIFEST_METHOD):
 		node.call(SET_MANIFEST_METHOD, mnfst)
 	for child in node.get_children():

--- a/ProcChunks.gd
+++ b/ProcChunks.gd
@@ -4,12 +4,14 @@ export var size = Vector2(3,3)
 
 const AutoChunk = preload("res://AutoChunk.tscn")
 const SceneStorage = preload("res://SceneStorage.gd")
+const StorageManifest = preload("res://StorageManifest.gd")
 const DeepZIndexHack = preload("res://DeepZIndexHack.gd")
 
 var active_chunks = {}
 var stored_chunks = {}
 
 onready var storage = SceneStorage.new()
+onready var manifest = StorageManifest.new()
 onready var dzi: DeepZIndexHack = $"/root/ProcFarm".find_node("DeepZIndexHack",true)
 
 func _ready():
@@ -64,6 +66,8 @@ func _on_player_entered_chunk(chunk_id: Vector2):
 var _pend_save = {}
 func save_chunk(cr, chunk_id: Vector2):
 	var chunk = cr.chunk
+	var chunk_manifest = manifest.generate(chunk, NodePath("."))
+	print("manifest : %s" % chunk_manifest)
 	storage.save_scene(chunk, cr["storage_name"])
 	remove_child(chunk)
 	active_chunks.erase(chunk_id)

--- a/ProcChunks.gd
+++ b/ProcChunks.gd
@@ -104,7 +104,6 @@ const SET_MANIFEST_METHOD = "set_manifest"
 func deep_set_manifests(node, mnfst: Dictionary):
 	print("%s (%s) chlrns %s" % [node,node.name,str(node.get_children())])
 	if node.has_method(SET_MANIFEST_METHOD):
-		print("node has set_manifest method " % node)
 		node.call(SET_MANIFEST_METHOD, mnfst)
 	for child in node.get_children():
 		deep_set_manifests(child, mnfst)

--- a/ProcChunks.gd
+++ b/ProcChunks.gd
@@ -90,6 +90,7 @@ func restore_chunk(file: String, chunk_id: Vector2):
 	chunk._storage_name = file
 	
 	if chunk_manifests.has(chunk_id):
+		print("set manifest %s" % chunk_manifests[chunk_id])
 		deep_set_manifests(chunk, chunk_manifests[chunk_id])
 
 	add_child(chunk, _RESTORE_WITH_LEGIBLE_NAMES)
@@ -100,11 +101,11 @@ func restore_chunk(file: String, chunk_id: Vector2):
 	_pend_restore.erase(chunk_id)
 
 const SET_MANIFEST_METHOD = "set_manifest"
-func deep_set_manifests(chunk, mnfst: Dictionary):
-	for child in chunk.get_children():
-		if child.has_method(SET_MANIFEST_METHOD):
-			print("child has method " % child)
-			child.call(SET_MANIFEST_METHOD, mnfst)
-		if child.get_child_count() > 0:
-			deep_set_manifests(child, mnfst)
+func deep_set_manifests(node, mnfst: Dictionary):
+	print("%s (%s) chlrns %s" % [node,node.name,str(node.get_children())])
+	if node.has_method(SET_MANIFEST_METHOD):
+		print("node has set_manifest method " % node)
+		node.call(SET_MANIFEST_METHOD, mnfst)
+	for child in node.get_children():
+		deep_set_manifests(child, mnfst)
 

--- a/ProcChunks.gd
+++ b/ProcChunks.gd
@@ -82,6 +82,9 @@ func restore_chunk(file: String, chunk_id: Vector2):
 	var chunk = storage.load_scene(file)
 	chunk.chunk_id = chunk_id
 	chunk._storage_name = file
+	
+	## TODO: descend through the chunk's scene tree and
+	##       call with_manifest() on each individual node
 	add_child(chunk)
 	chunk.set_owner(get_parent()) # set owner so that resource saving works
 	dzi.call("deep_zindex_hack", chunk)

--- a/ProcChunks.gd
+++ b/ProcChunks.gd
@@ -66,7 +66,7 @@ func _on_player_entered_chunk(chunk_id: Vector2):
 var _pend_save = {}
 func save_chunk(cr, chunk_id: Vector2):
 	var chunk = cr.chunk
-	var chunk_manifest = manifest.generate(chunk, NodePath("."))
+	var chunk_manifest = manifest.generate(chunk)
 	print("manifest : %s" % chunk_manifest)
 	storage.save_scene(chunk, cr["storage_name"])
 	remove_child(chunk)

--- a/ProcFencedCow.gd
+++ b/ProcFencedCow.gd
@@ -89,4 +89,4 @@ func _ready():
 
 	_manifest = fc
 	_manifest["zone"] = bb
-	print("it's set")
+

--- a/ProcFencedCow.gd
+++ b/ProcFencedCow.gd
@@ -73,4 +73,4 @@ func _ready():
 	
 	_manifest.clear()
 	_manifest = fc
-	_manifest["fence_rect2"] = bb
+	_manifest["zone"] = bb

--- a/ProcFencedCow.gd
+++ b/ProcFencedCow.gd
@@ -70,7 +70,6 @@ func _ready():
 	var force_proc_zone = false
 	if _manifest && !_manifest.empty():
 		var man_entry = StorageManifest.find_entry(self, _manifest)
-		print("procfencedcow manifest entry? %s" % man_entry)
 		if !man_entry.empty():
 			fc = man_entry
 			bb = man_entry["zone"]

--- a/ProcFencedCow.gd
+++ b/ProcFencedCow.gd
@@ -42,7 +42,7 @@ func gen_fence_tiles():
 	var num_tiles_x = int(min(Chunk.num_tiles_x - tile_offset_x, min_width + randi()%max_width))
 	var num_tiles_y = int(min(Chunk.num_tiles_y - tile_offset_y, min_height + randi()%max_height))
 	
-	return [tile_offset_x, tile_offset_y, num_tiles_x, num_tiles_y]
+	return {"tile_offset_x": tile_offset_x, "tile_offset_y":tile_offset_y, "num_tiles_x":num_tiles_x, "num_tiles_y":num_tiles_y}
 	
 func place_cow(tile_offset_x, tile_offset_y, width, height):
 	Cow.position.x = (tile_offset_x + 2 + randi()%(int(max(1,width-3)))) * Chunk.TILE_SIZE
@@ -57,16 +57,20 @@ func make_fence(bb):
 	fence.init(bb.size)
 	fence.position = bb.position
 	add_child(fence)
-	
+
+var _manifest = {}
+func manifest():
+	return _manifest
+
 func _ready():
 	randomize()
 	var fc = gen_fence_tiles()
-	var tile_offset_x = fc[0]
-	var tile_offset_y = fc[1]
-	var num_tiles_x = fc[2]
-	var num_tiles_y = fc[3]
-	var bb = pixel_bounding_box(tile_offset_x,tile_offset_y,num_tiles_x,num_tiles_y)
-	place_cow(tile_offset_x, tile_offset_y, num_tiles_x, num_tiles_y)
+	var bb = pixel_bounding_box(fc["tile_offset_x"], fc["tile_offset_y"], fc["num_tiles_x"], fc["num_tiles_y"])
+	place_cow(fc["tile_offset_x"], fc["tile_offset_y"], fc["num_tiles_x"], fc["num_tiles_y"])
 	animate_cow()
 	make_fence(bb)
 	ProcZoneRepo.try_add_proc_zone(bb, Chunk.id(self))
+	
+	_manifest.clear()
+	_manifest = fc
+	_manifest["fence_rect2"] = bb

--- a/ProcFencedCow.gd
+++ b/ProcFencedCow.gd
@@ -70,7 +70,6 @@ func _ready():
 	animate_cow()
 	make_fence(bb)
 	ProcZoneRepo.try_add_proc_zone(bb, Chunk.id(self))
-	
-	_manifest.clear()
+
 	_manifest = fc
 	_manifest["zone"] = bb

--- a/ProcFencedCow.gd
+++ b/ProcFencedCow.gd
@@ -61,15 +61,31 @@ func make_fence(bb):
 var _manifest = {}
 func manifest():
 	return _manifest
+func set_manifest(mfst: Dictionary):
+	self._manifest = mfst
 
 func _ready():
-	randomize()
-	var fc = gen_fence_tiles()
-	var bb = pixel_bounding_box(fc["tile_offset_x"], fc["tile_offset_y"], fc["num_tiles_x"], fc["num_tiles_y"])
+	var fc = {}
+	var bb = Rect2(0,0,0,0)
+	var force_proc_zone = false
+	if _manifest && !_manifest.empty():
+		var man_entry = StorageManifest.find_entry(self, _manifest)
+		print("procfencedcow manifest entry? %s" % man_entry)
+		if !man_entry.empty():
+			fc = man_entry
+			bb = man_entry["zone"]
+			force_proc_zone = true
+	else:
+		fc = gen_fence_tiles()
+		bb = pixel_bounding_box(fc["tile_offset_x"], fc["tile_offset_y"], fc["num_tiles_x"], fc["num_tiles_y"])
+	
 	place_cow(fc["tile_offset_x"], fc["tile_offset_y"], fc["num_tiles_x"], fc["num_tiles_y"])
 	animate_cow()
 	make_fence(bb)
-	ProcZoneRepo.try_add_proc_zone(bb, Chunk.id(self))
+	if force_proc_zone:
+		ProcZoneRepo.force_assign_zone(bb, Chunk.id(self))
+	else:
+		ProcZoneRepo.try_add_proc_zone(bb, Chunk.id(self))
 
 	_manifest = fc
 	_manifest["zone"] = bb

--- a/ProcFencedCow.gd
+++ b/ProcFencedCow.gd
@@ -89,3 +89,4 @@ func _ready():
 
 	_manifest = fc
 	_manifest["zone"] = bb
+	print("it's set")

--- a/ProcField.gd
+++ b/ProcField.gd
@@ -4,8 +4,6 @@ extends Node2D
 var width = Chunk.num_tiles_x   # in tiles
 var height = Chunk.num_tiles_y # in tiles
 
-# get a reference to the map for convenience
-onready var Map = $TileMap
 
 func rand_tile_id():
 	# tiles 4-7 are basic grass tiles
@@ -14,8 +12,15 @@ func rand_tile_id():
 func make_field():
 	for x in range(width):
 		for y in range(height):
-			var p = Vector2(x,y) #+ offset
-			Map.set_cellv(p, rand_tile_id())
+			$TileMap.set_cellv(Vector2(x,y), rand_tile_id())
+
+func manifest():
+	var m = {}
+	for x in range(width):
+		for y in range(height):
+			var pos = Vector2(x,y)
+			m[pos] = $TileMap.get_cellv(pos)
+	return m
 
 func _ready():
 	make_field()

--- a/ProcField.gd
+++ b/ProcField.gd
@@ -4,7 +4,6 @@ extends Node2D
 var width = Chunk.num_tiles_x   # in tiles
 var height = Chunk.num_tiles_y # in tiles
 
-
 func rand_tile_id():
 	# tiles 4-7 are basic grass tiles
 	return rand_range(4,7)
@@ -13,14 +12,6 @@ func make_field():
 	for x in range(width):
 		for y in range(height):
 			$TileMap.set_cellv(Vector2(x,y), rand_tile_id())
-
-func manifest():
-	var m = {}
-	for x in range(width):
-		for y in range(height):
-			var pos = Vector2(x,y)
-			m[pos] = $TileMap.get_cellv(pos)
-	return m
 
 func _ready():
 	make_field()

--- a/ProcPlants.gd
+++ b/ProcPlants.gd
@@ -90,7 +90,6 @@ func set_manifest(mfst: Dictionary):
 func _ready():
 	if _manifest && !_manifest.empty():
 		var man_entry = StorageManifest.find_entry(self, _manifest)
-		print("procpond manifest entry? %s" % man_entry)
 		if man_entry && !man_entry.empty() && man_entry.has(PLANT_TYPE_MANIFEST_KEY):
 			# override class vars
 			plant_type_num = man_entry[PLANT_TYPE_MANIFEST_KEY]

--- a/ProcPlants.gd
+++ b/ProcPlants.gd
@@ -76,6 +76,24 @@ onready var PLANT_SCENES = [
 
 onready var plant_type_num = randi()%PLANT_SCENES.size()
 
+const PLANT_TYPE_MANIFEST_KEY = "plant_type_num"
+const SIZE_MANIFEST_KEY = "size"
+
+onready var size = rand_size()
+func manifest() -> Dictionary:
+	return { PLANT_TYPE_MANIFEST_KEY: plant_type_num, SIZE_MANIFEST_KEY: size }
+
+var _manifest = {}
+func set_manifest(mfst: Dictionary):
+	self._manifest = mfst
+
 func _ready():
+	if _manifest && !_manifest.empty():
+		var man_entry = StorageManifest.find_entry(self, _manifest)
+		if man_entry && !man_entry.empty() && man_entry.has(PLANT_TYPE_MANIFEST_KEY):
+			plant_type_num = man_entry[PLANT_TYPE_MANIFEST_KEY]
+			size = man_entry[SIZE_MANIFEST_KEY]
+
 	var plot = AutoPlant.new(rand_size(),PLANT_SCENES[plant_type_num])
 	add_child(plot, true)
+	self._manifest = {}

--- a/ProcPlants.gd
+++ b/ProcPlants.gd
@@ -77,4 +77,4 @@ onready var plants = [
 
 func _ready():
 	var plot = plants[randi()%plants.size()]
-	add_child(plot)
+	add_child(plot, true)

--- a/ProcPlants.gd
+++ b/ProcPlants.gd
@@ -67,12 +67,12 @@ func rand_size():
 	return Vector2(max(96,randi()%int(size.x)), max (96,randi()%int(size.y)))
 
 onready var plants = [
-	auto_plant.new(rand_size(), ARTICHOKE_SCENES),
-	auto_plant.new(rand_size(), POTATO_SCENES),
-	auto_plant.new(rand_size(), CARROT_SCENES),
-	auto_plant.new(rand_size(), TOMATO_SCENES),
-	auto_plant.new(rand_size(), RED_PEPPER_SCENES),
-	auto_plant.new(rand_size(), CORN_SCENES),
+	auto_plant.new(rand_size(), ARTICHOKE_SCENES, "Artichoke"),
+	auto_plant.new(rand_size(), POTATO_SCENES, "Potato"),
+	auto_plant.new(rand_size(), CARROT_SCENES, "Carrot"),
+	auto_plant.new(rand_size(), TOMATO_SCENES, "Tomato"),
+	auto_plant.new(rand_size(), RED_PEPPER_SCENES, "Red Pepper"),
+	auto_plant.new(rand_size(), CORN_SCENES, "Corn"),
 ]
 
 func _ready():

--- a/ProcPlants.gd
+++ b/ProcPlants.gd
@@ -67,12 +67,12 @@ func rand_size():
 	return Vector2(max(96,randi()%int(size.x)), max (96,randi()%int(size.y)))
 
 onready var plants = [
-	auto_plant.new(rand_size(), ARTICHOKE_SCENES, "Artichoke"),
-	auto_plant.new(rand_size(), POTATO_SCENES, "Potato"),
-	auto_plant.new(rand_size(), CARROT_SCENES, "Carrot"),
-	auto_plant.new(rand_size(), TOMATO_SCENES, "Tomato"),
-	auto_plant.new(rand_size(), RED_PEPPER_SCENES, "Red Pepper"),
-	auto_plant.new(rand_size(), CORN_SCENES, "Corn"),
+	auto_plant.new(rand_size(), ARTICHOKE_SCENES),
+	auto_plant.new(rand_size(), POTATO_SCENES),
+	auto_plant.new(rand_size(), CARROT_SCENES),
+	auto_plant.new(rand_size(), TOMATO_SCENES),
+	auto_plant.new(rand_size(), RED_PEPPER_SCENES),
+	auto_plant.new(rand_size(), CORN_SCENES),
 ]
 
 func _ready():

--- a/ProcPlants.gd
+++ b/ProcPlants.gd
@@ -90,10 +90,13 @@ func set_manifest(mfst: Dictionary):
 func _ready():
 	if _manifest && !_manifest.empty():
 		var man_entry = StorageManifest.find_entry(self, _manifest)
+		print("procpond manifest entry? %s" % man_entry)
 		if man_entry && !man_entry.empty() && man_entry.has(PLANT_TYPE_MANIFEST_KEY):
+			# override class vars
 			plant_type_num = man_entry[PLANT_TYPE_MANIFEST_KEY]
 			size = man_entry[SIZE_MANIFEST_KEY]
 
-	var plot = AutoPlant.new(rand_size(),PLANT_SCENES[plant_type_num])
+	var plot = AutoPlant.new(size, PLANT_SCENES[plant_type_num])
+	plot.set_manifest(_manifest)
 	add_child(plot, true)
 	self._manifest = {}

--- a/ProcPlants.gd
+++ b/ProcPlants.gd
@@ -1,8 +1,9 @@
 extends Node2D
 
-export var size = Vector2(1024,1024)
+const MIN_SIZE = Vector2(96,96)
+export var max_size = Vector2(1024,1024)
 
-onready var TOMATO_SCENES = [
+const TOMATO_SCENES = [
 	preload("res://TomatoYoung.tscn"),
 	preload("res://TomatoGrowing.tscn"),
 	preload("res://TomatoGrowing2.tscn"),
@@ -10,7 +11,7 @@ onready var TOMATO_SCENES = [
 	preload("res://TomatoHarvested.tscn")
 ]
 
-onready var CARROT_SCENES = [
+const CARROT_SCENES = [
 	preload("res://CarrotYoung.tscn"),
 	preload("res://CarrotGrowing.tscn"),
 	preload("res://CarrotGrowing2.tscn"),
@@ -18,7 +19,7 @@ onready var CARROT_SCENES = [
 	preload("res://CarrotHarvested.tscn")
 ]
 
-onready var POTATO_SCENES = [
+const POTATO_SCENES = [
 	preload("res://PotatoYoung.tscn"),
 	preload("res://PotatoGrowing.tscn"),
 	preload("res://PotatoGrowing2.tscn"),
@@ -26,7 +27,7 @@ onready var POTATO_SCENES = [
 	preload("res://PotatoHarvested.tscn")
 ]
 
-onready var ARTICHOKE_SCENES = [
+const ARTICHOKE_SCENES = [
 	preload("res://ArtichokeYoung.tscn"), 
 	preload("res://ArtichokeGrowing.tscn"),
 	preload("res://ArtichokeGrowing2.tscn"),
@@ -34,8 +35,7 @@ onready var ARTICHOKE_SCENES = [
 	preload("res://ArtichokeHarvested.tscn")
 ]
 
-
-onready var RED_PEPPER_SCENES = [
+const RED_PEPPER_SCENES = [
 	preload("res://RedPepperYoung.tscn"), 
 	preload("res://RedPepperGrowing.tscn"),
 	preload("res://RedPepperGrowing2.tscn"),
@@ -43,8 +43,7 @@ onready var RED_PEPPER_SCENES = [
 	preload("res://RedPepperHarvested.tscn")
 ]
 
-
-onready var ZUCCHINI_SCENES = [
+const ZUCCHINI_SCENES = [
 	preload("res://ZucchiniYoung.tscn"), 
 	preload("res://ZucchiniGrowing.tscn"),
 	preload("res://ZucchiniGrowing2.tscn"),
@@ -52,7 +51,7 @@ onready var ZUCCHINI_SCENES = [
 	preload("res://ZucchiniHarvested.tscn")
 ]
 
-onready var CORN_SCENES = [
+const CORN_SCENES = [
 	preload("res://CornYoung.tscn"), 
 	preload("res://CornGrowing.tscn"),
 	preload("res://CornGrowing2.tscn"),
@@ -60,21 +59,23 @@ onready var CORN_SCENES = [
 	preload("res://CornHarvested.tscn")
 ]
 
-
-onready var auto_plant = load("res://AutoPlant.gd")
+const AutoPlant = preload("res://AutoPlant.gd")
 
 func rand_size():
-	return Vector2(max(96,randi()%int(size.x)), max (96,randi()%int(size.y)))
+	return Vector2(max(MIN_SIZE.x, randi()%int(max_size.x)),
+					max(MIN_SIZE.y, randi()%int(max_size.y)))
 
-onready var plants = [
-	auto_plant.new(rand_size(), ARTICHOKE_SCENES),
-	auto_plant.new(rand_size(), POTATO_SCENES),
-	auto_plant.new(rand_size(), CARROT_SCENES),
-	auto_plant.new(rand_size(), TOMATO_SCENES),
-	auto_plant.new(rand_size(), RED_PEPPER_SCENES),
-	auto_plant.new(rand_size(), CORN_SCENES),
+onready var PLANT_SCENES = [
+	ARTICHOKE_SCENES,
+	POTATO_SCENES,
+	CARROT_SCENES,
+	TOMATO_SCENES,
+	RED_PEPPER_SCENES,
+	CORN_SCENES,
 ]
 
+onready var plant_type_num = randi()%PLANT_SCENES.size()
+
 func _ready():
-	var plot = plants[randi()%plants.size()]
+	var plot = AutoPlant.new(rand_size(),PLANT_SCENES[plant_type_num])
 	add_child(plot, true)

--- a/ProcPonds.gd
+++ b/ProcPonds.gd
@@ -22,4 +22,4 @@ func _ready():
 		else:
 			pond.set_manifest(_manifest)
 		add_child(pond)
-	_manifest.clear()
+	_manifest = {}

--- a/ProcPonds.gd
+++ b/ProcPonds.gd
@@ -16,8 +16,10 @@ func set_manifest(mfst: Dictionary):
 func _ready():
 	for i in range(num_ponds):
 		var pond = AutoPond.instance()
-		pond.size = Vector2(max(min_size.x,randi()%int(max_size.x)),
-							max(min_size.y,randi()%int(max_size.y)))
-		pond.set_manifest(_manifest)
+		if _manifest == null || _manifest.empty():
+			pond.size = Vector2(max(min_size.x,randi()%int(max_size.x)),
+								max(min_size.y,randi()%int(max_size.y)))
+		else:
+			pond.set_manifest(_manifest)
 		add_child(pond)
 	_manifest.clear()

--- a/ProcPonds.gd
+++ b/ProcPonds.gd
@@ -15,4 +15,3 @@ func _ready():
 		pond.size = Vector2(max(min_size.x,randi()%int(max_size.x)),
 							max(min_size.y,randi()%int(max_size.y)))
 		add_child(pond)
-		print("placed pond at %s" % pond.position)

--- a/ProcPonds.gd
+++ b/ProcPonds.gd
@@ -9,9 +9,15 @@ const min_size = Vector2(64,64)
 
 const AutoPond = preload("res://AutoPond.tscn")
 
+var _manifest = {}
+func set_manifest(mfst: Dictionary):
+	self._manifest = mfst
+
 func _ready():
 	for i in range(num_ponds):
 		var pond = AutoPond.instance()
 		pond.size = Vector2(max(min_size.x,randi()%int(max_size.x)),
 							max(min_size.y,randi()%int(max_size.y)))
+		pond.set_manifest(_manifest)
 		add_child(pond)
+	_manifest.clear()

--- a/ProcZoneRepo.gd
+++ b/ProcZoneRepo.gd
@@ -18,11 +18,14 @@ func assign_zone(size: Vector2, chunk_id: Vector2):
 		print("failed to assign zone with size %s" % size)
 	return c
 
+func force_assign_zone(zone: Rect2, chunk_id: Vector2):
+	if !proc_zones.has(chunk_id):
+		proc_zones[chunk_id] = []
+	proc_zones[chunk_id].push_front(zone)
+
 func try_add_proc_zone(zone: Rect2, chunk_id: Vector2):
 	if !contains(zone, chunk_id):
-		if !proc_zones.has(chunk_id):
-			proc_zones[chunk_id] = []
-		proc_zones[chunk_id].push_front(zone)
+		force_assign_zone(zone, chunk_id)
 		return true
 	return false
 	

--- a/StorageManifest.gd
+++ b/StorageManifest.gd
@@ -18,7 +18,7 @@ static func trim_path(p: NodePath):
 	for x in range(nc):
 		if p.get_name(x).match (PATH_MATCH):
 			idx = x
-	var trimmed = ""
+	var trimmed = "./"
 	var lim = nc - idx
 	for y in range(lim):
 		trimmed += p.get_name(y + idx)

--- a/StorageManifest.gd
+++ b/StorageManifest.gd
@@ -44,7 +44,7 @@ func generate(node: Node, accum: Dictionary = {}):
 func position_manifest(node: Node):
 	return { "position_x": node.position.x, "position_y": node.position.y }
 
-func size_position_manifest(node: Node):
+func size_position_manifest(node):
 	return {
 			"size_x": node.size.x,
 			"size_y": node.size.y,

--- a/StorageManifest.gd
+++ b/StorageManifest.gd
@@ -1,17 +1,35 @@
 extends Node
 
+const HouseThatchedRoof = preload("res://HouseThatchedRoof.gd")
+
 ## TODO TODO TODO
 ## Figure out how to deal with the scene tree
 ## in some recursive (and accurate) fashion
 
+static func merge_dir(target, patch):
+	for key in patch:
+		if target.has(key):
+			var tv = target[key]
+			if typeof(tv) == TYPE_DICTIONARY:
+				merge_dir(tv, patch[key])
+			else:
+				target[key] = patch[key]
+		else:
+		    target[key] = patch[key]
+
 ## Generate a storage manifest for a given type of node
 ## It should return a dictionary with reasonably-formatted
 ## information on the position of landmarks, etc.
-func generate(node: Node, path: NodePath, accum: Dictionary):
+static func generate(node: Node, accum: Dictionary = {}):
+	var path = node.get_path()
 	# position-only classes
-	if node.get_class() in ["HouseThatchedRoof"]:
-		return { path: { "position": node.position } }
-	elif node.get_class() == "ProcFencedCow":
-		return {}
+	if node is HouseThatchedRoof:
+		accum[path] = { "position": node.position }
+	#elif node.get_class() == "ProcFencedCow":
+	#	return {}
 	
-	return { path: "Nope" }
+	for c in node.get_children():
+		var child_accum = generate(c, accum)
+		merge_dir(accum, child_accum)
+	
+	return accum

--- a/StorageManifest.gd
+++ b/StorageManifest.gd
@@ -1,6 +1,6 @@
 extends Node
 
-static func merge_dir(target, patch):
+func merge_dir(target, patch):
 	for key in patch:
 		if target.has(key):
 			var tv = target[key]
@@ -12,7 +12,7 @@ static func merge_dir(target, patch):
 		    target[key] = patch[key]
 
 const PATH_MATCH = "*AutoChunk*"
-static func trim_path(p: NodePath):
+func trim_path(p: NodePath):
 	var idx = 0
 	var nc = p.get_name_count()
 	for x in range(nc):
@@ -29,7 +29,7 @@ static func trim_path(p: NodePath):
 ## Generate a storage manifest for a given type of node
 ## It should return a dictionary with reasonably-formatted
 ## information on the position of landmarks, etc.
-static func generate(node: Node, accum: Dictionary = {}):
+func generate(node: Node, accum: Dictionary = {}):
 	var path = trim_path(node.get_path())
 
 	if node.has_method("manifest"):
@@ -41,11 +41,20 @@ static func generate(node: Node, accum: Dictionary = {}):
 	
 	return accum
 
-static func position_manifest(node: Node):
+func position_manifest(node: Node):
 	return { "position": node.position }
 
-static func size_position_manifest(node: Node):
+func size_position_manifest(node: Node):
 	return {
 			"size": node.size,
 			"position": node.position
 		}
+
+func find_entry(node_path: NodePath, manifst: Dictionary) -> Dictionary:
+	var found: Dictionary = {}
+	for k in manifst.keys():
+		if k == node_path:
+			found = manifst[k]
+			print("FOUND MANIFEST %s" % found)
+			break
+	return found

--- a/StorageManifest.gd
+++ b/StorageManifest.gd
@@ -1,13 +1,17 @@
 extends Node
 
+## TODO TODO TODO
+## Figure out how to deal with the scene tree
+## in some recursive (and accurate) fashion
+
 ## Generate a storage manifest for a given type of node
 ## It should return a dictionary with reasonably-formatted
 ## information on the position of landmarks, etc.
-func generate(node: Node):
+func generate(node: Node, path: NodePath, accum: Dictionary):
 	# position-only classes
 	if node.get_class() in ["HouseThatchedRoof"]:
-		return { "position": node.position }
+		return { path: { "position": node.position } }
 	elif node.get_class() == "ProcFencedCow":
 		return {}
 	
-	return {}
+	return { path: "Nope" }

--- a/StorageManifest.gd
+++ b/StorageManifest.gd
@@ -1,12 +1,5 @@
 extends Node
 
-const AutoPond = preload("res://AutoPond.gd")
-const HouseThatchedRoof = preload("res://HouseThatchedRoof.gd")
-
-## TODO TODO TODO
-## Figure out how to deal with the scene tree
-## in some recursive (and accurate) fashion
-
 static func merge_dir(target, patch):
 	for key in patch:
 		if target.has(key):
@@ -23,19 +16,21 @@ static func merge_dir(target, patch):
 ## information on the position of landmarks, etc.
 static func generate(node: Node, accum: Dictionary = {}):
 	var path = node.get_path()
-	# position-only classes
-	if node is HouseThatchedRoof:
-		accum[path] = { "position": node.position }
-	elif node is AutoPond:
-		accum[path] = {
-			"size": node.size,
-			"position": node.position
-		}
-	#elif node.get_class() == "ProcFencedCow":
-	#	return {}
+
+	if node.has_method("manifest"):
+		accum[path] = node.call("manifest")
 	
 	for c in node.get_children():
 		var child_accum = generate(c, accum)
 		merge_dir(accum, child_accum)
 	
 	return accum
+
+static func position_manifest(node: Node):
+	return { "position": node.position }
+
+static func size_position_manifest(node: Node):
+	return {
+			"size": node.size,
+			"position": node.position
+		}

--- a/StorageManifest.gd
+++ b/StorageManifest.gd
@@ -41,8 +41,6 @@ static func generate(node: Node, accum: Dictionary = {}):
 	
 	return accum
 
-
-
 static func position_manifest(node: Node):
 	return { "position": node.position }
 

--- a/StorageManifest.gd
+++ b/StorageManifest.gd
@@ -11,11 +11,26 @@ static func merge_dir(target, patch):
 		else:
 		    target[key] = patch[key]
 
+const PATH_MATCH = "*AutoChunk*"
+static func trim_path(p: NodePath):
+	var idx = 0
+	var nc = p.get_name_count()
+	for x in range(nc):
+		if p.get_name(x).match (PATH_MATCH):
+			idx = x
+	var trimmed = ""
+	var lim = nc - idx
+	for y in range(lim):
+		trimmed += p.get_name(y + idx)
+		if y != lim - 1:
+			trimmed += "/"
+	return NodePath(trimmed)
+
 ## Generate a storage manifest for a given type of node
 ## It should return a dictionary with reasonably-formatted
 ## information on the position of landmarks, etc.
 static func generate(node: Node, accum: Dictionary = {}):
-	var path = node.get_path()
+	var path = trim_path(node.get_path())
 
 	if node.has_method("manifest"):
 		accum[path] = node.call("manifest")
@@ -25,6 +40,8 @@ static func generate(node: Node, accum: Dictionary = {}):
 		merge_dir(accum, child_accum)
 	
 	return accum
+
+
 
 static func position_manifest(node: Node):
 	return { "position": node.position }

--- a/StorageManifest.gd
+++ b/StorageManifest.gd
@@ -1,0 +1,13 @@
+extends Node
+
+## Generate a storage manifest for a given type of node
+## It should return a dictionary with reasonably-formatted
+## information on the position of landmarks, etc.
+func generate(node: Node):
+	# position-only classes
+	if node.get_class() in ["HouseThatchedRoof"]:
+		return { "position": node.position }
+	elif node.get_class() == "ProcFencedCow":
+		return {}
+	
+	return {}

--- a/StorageManifest.gd
+++ b/StorageManifest.gd
@@ -42,12 +42,14 @@ func generate(node: Node, accum: Dictionary = {}):
 	return accum
 
 func position_manifest(node: Node):
-	return { "position": node.position }
+	return { "position_x": node.position.x, "position_y": node.position.y }
 
 func size_position_manifest(node: Node):
 	return {
-			"size": node.size,
-			"position": node.position
+			"size_x": node.size.x,
+			"size_y": node.size.y,
+			"position_x": node.position.x,
+			"position_y": node.position.y,
 		}
 
 func find_entry(node_path: NodePath, manifst: Dictionary) -> Dictionary:

--- a/StorageManifest.gd
+++ b/StorageManifest.gd
@@ -1,5 +1,6 @@
 extends Node
 
+const AutoPond = preload("res://AutoPond.gd")
 const HouseThatchedRoof = preload("res://HouseThatchedRoof.gd")
 
 ## TODO TODO TODO
@@ -25,6 +26,11 @@ static func generate(node: Node, accum: Dictionary = {}):
 	# position-only classes
 	if node is HouseThatchedRoof:
 		accum[path] = { "position": node.position }
+	elif node is AutoPond:
+		accum[path] = {
+			"size": node.size,
+			"position": node.position
+		}
 	#elif node.get_class() == "ProcFencedCow":
 	#	return {}
 	

--- a/StorageManifest.gd
+++ b/StorageManifest.gd
@@ -54,11 +54,9 @@ func size_position_manifest(node):
 
 func find_entry(node: Node, manifst: Dictionary) -> Dictionary:
 	var node_path = trim_path(node.get_path())
-	print("node path %s" % node_path)
 	var found: Dictionary = {}
 	for k in manifst.keys():
 		if k == node_path:
 			found = manifst[k]
-			print("FOUND MANIFEST %s" % found)
 			break
 	return found

--- a/StorageManifest.gd
+++ b/StorageManifest.gd
@@ -60,3 +60,12 @@ func find_entry(node: Node, manifst: Dictionary) -> Dictionary:
 			found = manifst[k]
 			break
 	return found
+
+const NO_ZONE = Rect2(0,0,0,0)
+func find_zone(node, mfst: Dictionary, default: Rect2 = Rect2(0,0,0,0)) -> Rect2:
+	var entry = StorageManifest.find_entry(node, mfst)
+	return Rect2(
+			Vector2(entry.get("position_x",default.position.x),
+					entry.get("position_y",default.position.y)),
+			Vector2(entry.get("size_x",default.size.x),
+				    entry.get("size_y",default.size.y)))

--- a/StorageManifest.gd
+++ b/StorageManifest.gd
@@ -52,7 +52,9 @@ func size_position_manifest(node: Node):
 			"position_y": node.position.y,
 		}
 
-func find_entry(node_path: NodePath, manifst: Dictionary) -> Dictionary:
+func find_entry(node: Node, manifst: Dictionary) -> Dictionary:
+	var node_path = trim_path(node.get_path())
+	print("node path %s" % node_path)
 	var found: Dictionary = {}
 	for k in manifst.keys():
 		if k == node_path:

--- a/project.godot
+++ b/project.godot
@@ -26,6 +26,7 @@ Chunk="*res://Chunk.tscn"
 ZIndex="*res://ZIndex.gd"
 PlowmanInput="*res://PlowmanInput.gd"
 ProcZoneRepo="*res://ProcZoneRepo.gd"
+StorageManifest="*res://StorageManifest.gd"
 
 [rendering]
 


### PR DESCRIPTION
This change set implements logic such that a procedurally generated house will be positioned in the same place after being stored and then reloaded to disk, plants will have the same position (if not already collected), chickens will have the same zone (if not already collected), ponds will have the same position and size, etc.

Fixes collision area duplication.

Advances #30.